### PR TITLE
fix bug

### DIFF
--- a/ADTickerLabel.m
+++ b/ADTickerLabel.m
@@ -90,7 +90,7 @@
             selectedCharacterIndex++;
         }
         
-        if(selectedCharacterIndex < self.selectedCharacterIndex){
+        if(selectedCharacterIndex <= self.selectedCharacterIndex){
             
             [self animateToPositionY:[self positionYForCharacterAtIndex: selectedCharacterIndex] withCallback:^{
                 self.selectedCharacter = selectedCharacter;


### PR DESCRIPTION
If the second text has the same prefix digit with the first text and longer than the first text,the prefix digit will become 0.
(e.g. change text from 200 to 2200, the result become 0200. )
