### PR TITLE
Refactored animations to use CATransition

### DIFF
--- a/ADTickerLabel.h
+++ b/ADTickerLabel.h
@@ -36,7 +36,7 @@ typedef enum{
 /*
  Default UITextAlignmentLeft
  */
-@property (nonatomic, assign) UITextAlignment textAlignment;
+@property (nonatomic, assign) NSTextAlignment textAlignment;
 
 /*
  Default 1.0

--- a/ADTickerLabel.h
+++ b/ADTickerLabel.h
@@ -16,7 +16,7 @@ typedef enum{
 @interface ADTickerLabel : UIView
 
 @property (nonatomic, strong) UIFont *font;
-@property (nonatomic, strong) UIColor *textColor;
+@property (nonatomic, strong) IBInspectable UIColor *textColor;
 
 /*
  Default ADTickerLabelScrollDirectionUp
@@ -26,12 +26,12 @@ typedef enum{
 /*
  Default nil
  */
-@property (nonatomic, strong) UIColor *shadowColor;
+@property (nonatomic, strong) IBInspectable UIColor *shadowColor;
 
 /*
  Default CGSizeMake(0, 0)
  */
-@property (nonatomic, assign) CGSize shadowOffset;
+@property (nonatomic, assign) IBInspectable CGSize shadowOffset;
 
 /*
  Default UITextAlignmentLeft
@@ -41,9 +41,9 @@ typedef enum{
 /*
  Default 1.0
  */
-@property (nonatomic, assign) NSTimeInterval changeTextAnimationDuration;
+@property (nonatomic, assign) IBInspectable CGFloat animationDuration;
 
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) IBInspectable NSString *text;
 
 -(void)setText:(NSString *)text animated:(BOOL)animated;
 

--- a/ADTickerLabel.m
+++ b/ADTickerLabel.m
@@ -49,7 +49,7 @@
 
    self.font = [UIFont systemFontOfSize: 12.];
    self.textColor = [UIColor blackColor];
-   self.changeTextAnimationDuration = 1.0;
+   self.animationDuration = 1.0;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
@@ -176,7 +176,7 @@
    CATransition *transition = [CATransition animation];
    
    transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
-   transition.duration = self.changeTextAnimationDuration;
+   transition.duration = self.animationDuration;
    transition.type = kCATransitionPush;
    
    transition.subtype = scrollDirection == ADTickerLabelScrollDirectionUp ? kCATransitionFromTop : kCATransitionFromBottom;

--- a/ADTickerLabel.m
+++ b/ADTickerLabel.m
@@ -200,6 +200,7 @@
    characterFrame.size = CGSizeMake(self.characterWidth, self.bounds.size.height);
    
    ADTickerCharacterLabel *characterLabel = [[ADTickerCharacterLabel alloc] initWithFrame: characterFrame];
+   characterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleRightMargin;
    characterLabel.textAlignment = NSTextAlignmentCenter;
    characterLabel.font = self.font;
    characterLabel.textColor = self.textColor;
@@ -213,7 +214,17 @@
 
 - (void)removeLastCharacterLabel:(BOOL)animated
 {
-   ADTickerCharacterLabel *label = self.characterViews.lastObject;
+   ADTickerCharacterLabel *label = nil;
+   
+   if (self.textAlignment == NSTextAlignmentRight)
+   {
+      label = self.characterViews.firstObject;
+   }
+   else
+   {
+      label = self.characterViews.lastObject;
+   }
+   
    [self.characterViews removeObject:label];
    
    if (animated)

--- a/ADTickerLabel.podspec
+++ b/ADTickerLabel.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/Antondomashnev"
   s.author       = { 'Anton Domashnev' => 'antondomashnev@gmail.com' }
   s.source       = { :git => "https://github.com/Antondomashnev/ADTickerLabel.git", :tag => s.version.to_s}
-  s.platform     = :ios
+  s.platform     = :ios, '8.0'
   s.source_files = '*.{h,m}'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.framework    = 'CoreGraphics', 'QuartzCore'

--- a/ADTickerLabel/ViewController.m
+++ b/ADTickerLabel/ViewController.m
@@ -24,7 +24,7 @@
    [super viewDidLoad];
 
    self.currentIndex = 0;
-   self.numbersArray = @[@1, @29, @30, @31, @30, @33];
+   self.numbersArray = @[@1, @29, @1098.7, @89, @18741984, @897];
 
    UIFont *font = [UIFont fontWithName: @"HelveticaNeue-Light" size: 20];
    self.tickerLabel = [[ADTickerLabel alloc] initWithFrame: CGRectMake(50, 50, 100, font.lineHeight)];
@@ -36,21 +36,18 @@
    [self.view addSubview: self.tickerLabel];
 }
 
-- (void)didReceiveMemoryWarning
-{
-   [super didReceiveMemoryWarning];
-   // Dispose of any resources that can be recreated.
-}
-
 - (IBAction)buttonClicked:(id)sender{
-   
    self.tickerLabel.text = [NSString stringWithFormat:@"%d", self.tickerLabel.text.intValue+1];
-   
-   self.currentIndex++;
-   if(self.currentIndex == [self.numbersArray count]) self.currentIndex = 0;
 }
 - (IBAction)decrementButtonClicked:(id)sender {
    self.tickerLabel.text = [NSString stringWithFormat:@"%d", self.tickerLabel.text.intValue-1];
+}
+
+- (IBAction)randomButtonClicked:(id)sender {
+   self.tickerLabel.text = [NSString stringWithFormat:@"%@", self.numbersArray[self.currentIndex]];
+   
+   self.currentIndex++;
+   if(self.currentIndex == [self.numbersArray count]) self.currentIndex = 0;
 }
 
 @end

--- a/ADTickerLabel/ViewController.m
+++ b/ADTickerLabel/ViewController.m
@@ -24,13 +24,15 @@
    [super viewDidLoad];
 
    self.currentIndex = 0;
-   self.numbersArray = @[@1, @29, @1098.7, @89, @18741984, @897];
+   self.numbersArray = @[@1, @29, @30, @31, @30, @33];
 
    UIFont *font = [UIFont fontWithName: @"HelveticaNeue-Light" size: 20];
    self.tickerLabel = [[ADTickerLabel alloc] initWithFrame: CGRectMake(50, 50, 100, font.lineHeight)];
    self.tickerLabel.font = font;
-   self.tickerLabel.textAlignment = NSTextAlignmentCenter;
+   self.tickerLabel.textAlignment = NSTextAlignmentLeft;
    self.tickerLabel.changeTextAnimationDuration = 0.5;
+   self.tickerLabel.scrollDirection = ADTickerLabelScrollDirectionDown;
+   [self.tickerLabel setText:@"0" animated:NO];
    [self.view addSubview: self.tickerLabel];
 }
 
@@ -42,10 +44,13 @@
 
 - (IBAction)buttonClicked:(id)sender{
    
-   self.tickerLabel.text = [NSString stringWithFormat:@"%@", self.numbersArray[self.currentIndex]];
+   self.tickerLabel.text = [NSString stringWithFormat:@"%d", self.tickerLabel.text.intValue+1];
    
    self.currentIndex++;
    if(self.currentIndex == [self.numbersArray count]) self.currentIndex = 0;
+}
+- (IBAction)decrementButtonClicked:(id)sender {
+   self.tickerLabel.text = [NSString stringWithFormat:@"%d", self.tickerLabel.text.intValue-1];
 }
 
 @end

--- a/ADTickerLabel/ViewController.m
+++ b/ADTickerLabel/ViewController.m
@@ -30,7 +30,7 @@
    self.tickerLabel = [[ADTickerLabel alloc] initWithFrame: CGRectMake(50, 50, 100, font.lineHeight)];
    self.tickerLabel.font = font;
    self.tickerLabel.textAlignment = NSTextAlignmentLeft;
-   self.tickerLabel.changeTextAnimationDuration = 0.5;
+   self.tickerLabel.animationDuration = 0.5;
    self.tickerLabel.scrollDirection = ADTickerLabelScrollDirectionDown;
    [self.tickerLabel setText:@"0" animated:NO];
    [self.view addSubview: self.tickerLabel];

--- a/ADTickerLabel/en.lproj/ViewController.xib
+++ b/ADTickerLabel/en.lproj/ViewController.xib
@@ -1,205 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIButton</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="843779117">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="774585933">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUIButton" id="325379879">
-						<reference key="NSNextResponder" ref="774585933"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{73, 465}, {73, 44}}</string>
-						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Button</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleShadowColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">2</int>
-							<double key="pointSize">15</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="325379879"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MC43NQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
-				</object>
-				<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<array key="dict.sortedKeys">
-							<integer value="1"/>
-							<integer value="3"/>
-						</array>
-						<array key="dict.values">
-							<string>{320, 568}</string>
-							<string>{568, 320}</string>
-						</array>
-					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
-					<int key="IBUIType">2</int>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="774585933"/>
-					</object>
-					<int key="connectionID">7</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">buttonClicked:</string>
-						<reference key="source" ref="325379879"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">13</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="843779117"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="774585933"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="325379879"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">8</int>
-						<reference key="object" ref="325379879"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">ViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">13</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">ViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">buttonClicked:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">buttonClicked:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">buttonClicked:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/ViewController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9046" systemVersion="15B17c" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9035"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController">
+            <connections>
+                <outlet property="view" destination="6" id="7"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="6">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
+                    <rect key="frame" x="72" y="485" width="75" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                    <state key="normal" title="increment">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="buttonClicked:" destination="-1" eventType="touchUpInside" id="13"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="DX3-F4-WOb">
+                    <rect key="frame" x="229" y="492" width="74" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <animations/>
+                    <state key="normal" title="decrement"/>
+                    <connections>
+                        <action selector="decrementButtonClicked:" destination="-1" eventType="touchUpInside" id="ZmQ-b9-KIQ"/>
+                    </connections>
+                </button>
+            </subviews>
+            <animations/>
+            <color key="backgroundColor" white="0.75" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+        </view>
+    </objects>
+</document>

--- a/ADTickerLabel/en.lproj/ViewController.xib
+++ b/ADTickerLabel/en.lproj/ViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9046" systemVersion="15B17c" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9046" systemVersion="15B30a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9035"/>
@@ -16,7 +16,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
-                    <rect key="frame" x="72" y="485" width="75" height="44"/>
+                    <rect key="frame" x="8" y="485" width="75" height="44"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -28,12 +28,25 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="DX3-F4-WOb">
-                    <rect key="frame" x="229" y="492" width="74" height="30"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <rect key="frame" x="238" y="492" width="74" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <state key="normal" title="decrement"/>
                     <connections>
                         <action selector="decrementButtonClicked:" destination="-1" eventType="touchUpInside" id="ZmQ-b9-KIQ"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="WYH-1e-h4K">
+                    <rect key="frame" x="123" y="485" width="75" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                    <state key="normal" title="random">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="buttonClicked:" destination="-1" eventType="touchUpInside" id="qCc-5U-nml"/>
+                        <action selector="randomButtonClicked:" destination="-1" eventType="touchUpInside" id="nZY-2I-AoN"/>
                     </connections>
                 </button>
             </subviews>


### PR DESCRIPTION
Hey, I just made a refactoring of ADTickerLabel and changed the way, the animations are handled.

The intention was to fix the animations when incrementing and decrementing the numbers by 1 to use it as a counter label for likes (like in Tumblr). But it also works nice with bigger changes. Especially when changing from 9 to 10, the animations look correct now. Down- and up-directions work as intended. And the animation, when removing labels is also pimped a little bit.
It looks best with LeftAlignment. RightAlignment is okay, but could be improved when switching from 9 to 10.

It works and looks a bit different now (check out the example app), so let me know if you like it, otherwise I will just keep it as a fork ;)
